### PR TITLE
Feature/add meta query visibility logic to existing value

### DIFF
--- a/plugins/bcc-login/includes/class-bcc-login-settings.php
+++ b/plugins/bcc-login/includes/class-bcc-login-settings.php
@@ -151,7 +151,7 @@ class BCC_Login_Settings_Provider {
                 'value' => $this->_settings->client_id,
                 'label' => __( 'ClientID', 'client_id' ),
                 'readonly' => 1,
-                'description' => 'OIDC variables can be configured using environment variables or constants in wpconfig.php. Commonly used variables: <i>OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_SCOPE</i>'
+                'description' => 'OIDC variables can be configured using environment variables or constants in wp-config.php. Commonly used variables: <i>OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_SCOPE</i>'
             )
         );
 

--- a/plugins/bcc-login/includes/class-bcc-login-visibility.php
+++ b/plugins/bcc-login/includes/class-bcc-login-visibility.php
@@ -168,36 +168,35 @@ class BCC_Login_Visibility {
 
         if ( $this->_settings->default_visibility == self::VISIBILITY_PUBLIC ) {
             // If default visibility is public, show posts where visibility matches current user level OR where visibility isn't defined
-            $query->set(
-                'meta_query',
-                array(
-                    'relation' => 'OR',
+            $query->set('meta_query', 
+                array_merge((array)$query->query_vars['meta_query'], array(
                     array(
-                        'key'     => 'bcc_login_visibility',
-                        'compare' => '<=',
-                        'value'   => $this->get_current_user_level(),
-                    ),
-                    array(
-                        'key'     => 'bcc_login_visibility',
-                        'compare' => 'NOT EXISTS',
-                    ),
-                )
+                        'relation' => 'OR',
+                        array(
+                            'key'     => 'bcc_login_visibility',
+                            'compare' => '<=',
+                            'value'   => $this->get_current_user_level(),
+                        ),
+                        array(
+                            'key'     => 'bcc_login_visibility',
+                            'compare' => 'NOT EXISTS',
+                        ),
+                    )
+                ))
             );
         } else {
             // Don't include posts where visibility isn't specified if default visibility isn't public
             $query->set(
                 'meta_query',
-                array(
+                array_merge((array)$query->query_vars['meta_query'], array(
                     array(
                         'key'     => 'bcc_login_visibility',
                         'compare' => '<=',
                         'value'   => $this->get_current_user_level(),
                     )
-                )
+                ))
             );
         }
-
-
 
         return $query;
     }

--- a/plugins/bcc-login/includes/class-bcc-login-visibility.php
+++ b/plugins/bcc-login/includes/class-bcc-login-visibility.php
@@ -168,34 +168,42 @@ class BCC_Login_Visibility {
 
         if ( $this->_settings->default_visibility == self::VISIBILITY_PUBLIC ) {
             // If default visibility is public, show posts where visibility matches current user level OR where visibility isn't defined
-            $query->set('meta_query', 
-                array_merge((array)$query->query_vars['meta_query'], array(
-                    array(
-                        'relation' => 'OR',
-                        array(
-                            'key'     => 'bcc_login_visibility',
-                            'compare' => '<=',
-                            'value'   => $this->get_current_user_level(),
-                        ),
-                        array(
-                            'key'     => 'bcc_login_visibility',
-                            'compare' => 'NOT EXISTS',
-                        ),
-                    )
-                ))
+ 
+            // Get original meta query
+            $meta_query = (array)$query->get('meta_query');
+
+            // Add visibility rules
+            $meta_query[] = array(
+                'relation' => 'OR',
+                array(
+                    'key'     => 'bcc_login_visibility',
+                    'compare' => '<=',
+                    'value'   => $this->get_current_user_level(),
+                ),
+                array(
+                    'key'     => 'bcc_login_visibility',
+                    'compare' => 'NOT EXISTS',
+                ),
             );
-        } else {
+
+            // Set the meta query to the complete, altered query
+            $query->set('meta_query', $meta_query);
+        } 
+        else {
             // Don't include posts where visibility isn't specified if default visibility isn't public
-            $query->set(
-                'meta_query',
-                array_merge((array)$query->query_vars['meta_query'], array(
-                    array(
-                        'key'     => 'bcc_login_visibility',
-                        'compare' => '<=',
-                        'value'   => $this->get_current_user_level(),
-                    )
-                ))
+
+            // Get original meta query
+            $meta_query = (array)$query->get('meta_query');
+
+            // Add visibility rules
+            $meta_query[] =  array(
+                'key'     => 'bcc_login_visibility',
+                'compare' => '<=',
+                'value'   => $this->get_current_user_level(),
             );
+
+            // Set the meta query to the complete, altered query
+            $query->set('meta_query', $meta_query);
         }
 
         return $query;


### PR DESCRIPTION
It is also possible that a query does not have the index meta_query so the previous code could return a notice about undefined index.
This code uses WP function get() to also check for an empty value.