### PR TITLE
Exclude the topbar in JSON requests

### DIFF
--- a/plugins/bcc-login/includes/class-bcc-login-widgets.php
+++ b/plugins/bcc-login/includes/class-bcc-login-widgets.php
@@ -35,7 +35,11 @@ class BCC_Login_Widgets {
     }
 
     function should_show_topbar() {
-        $user = wp_get_current_user();
-        return $user->exists() && $this->settings->topbar && ! is_customize_preview();
+        return (
+            $this->settings->topbar &&
+            wp_get_current_user()->exists() &&
+            ! wp_is_json_request() &&
+            ! is_customize_preview()
+        );
     }
 }


### PR DESCRIPTION
This PR ensures the topbar is excluded when rendering the widget preview iframes in the customizer.