### PR TITLE
fix login redirect caching

### DIFF
--- a/plugins/bcc-login/includes/class-bcc-login-client.php
+++ b/plugins/bcc-login/includes/class-bcc-login-client.php
@@ -276,7 +276,7 @@ class BCC_Login_Client {
         if( get_option('permalink_structure') != "")
             return add_query_arg( $_SERVER['QUERY_STRING'], '', home_url( $wp->request ) );
         
-            if(isset($_GET['redirect_to'])) 
+        if(isset($_GET['redirect_to'])) 
             return $_GET['redirect_to'];
 
         return $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . str_replace('wp-login.php', 'wp-admin', $_SERVER['REQUEST_URI']);

--- a/plugins/bcc-login/includes/class-bcc-login-client.php
+++ b/plugins/bcc-login/includes/class-bcc-login-client.php
@@ -273,9 +273,14 @@ class BCC_Login_Client {
 
         // If the Permalink Structure is set to Plain we use the old solution with $_SERVER
         // We replace 'wp-login.php' to 'wp-admin' to avoid the redirect loop when logging through SSO directly to the admin dashboard
-        return get_option('permalink_structure') == ""
-            ? $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . str_replace('wp-login.php', 'wp-admin', $_SERVER['REQUEST_URI'])
-            : add_query_arg( $_SERVER['QUERY_STRING'], '', home_url( $wp->request ) );
+        if( get_option('permalink_structure') != "")
+            return add_query_arg( $_SERVER['QUERY_STRING'], '', home_url( $wp->request ) );
+        
+            if(isset($_GET['redirect_to'])) 
+            return $_GET['redirect_to'];
+
+        return $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . str_replace('wp-login.php', 'wp-admin', $_SERVER['REQUEST_URI']);
+            
     }
 
     private function get_authorization_url( Auth_State $state ) {

--- a/plugins/bcc-login/includes/class-bcc-login-client.php
+++ b/plugins/bcc-login/includes/class-bcc-login-client.php
@@ -277,8 +277,6 @@ class BCC_Login_Client {
             return add_query_arg( $_SERVER['QUERY_STRING'], '', home_url( $wp->request ) );
         
         if(isset($_GET['redirect_to'])) {
-            $redirect_url_origin = $this->parse_url_origin($_GET['redirect_to']);
-
             if( $this->parse_url_origin($_GET['redirect_to']) !==  $this->parse_url_origin(site_url()) ) {
                 return "/";
             }

--- a/plugins/bcc-login/includes/class-bcc-login-client.php
+++ b/plugins/bcc-login/includes/class-bcc-login-client.php
@@ -276,11 +276,38 @@ class BCC_Login_Client {
         if( get_option('permalink_structure') != "")
             return add_query_arg( $_SERVER['QUERY_STRING'], '', home_url( $wp->request ) );
         
-        if(isset($_GET['redirect_to'])) 
+        if(isset($_GET['redirect_to'])) {
+            $redirect_url_origin = $this->parse_url_origin($_GET['redirect_to']);
+
+            if( $this->parse_url_origin($_GET['redirect_to']) !==  $this->parse_url_origin(site_url()) ) {
+                return "/";
+            }
+            
             return $_GET['redirect_to'];
+        }
 
         return $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . str_replace('wp-login.php', 'wp-admin', $_SERVER['REQUEST_URI']);
             
+    }
+
+    private function parse_url_origin($url) {
+        $origin = "";
+
+        $parsed = parse_url($url);
+
+        if ($parsed === false) {
+            return $origin;
+        }
+        if(isset($parsed['scheme']))
+            $origin .= $parsed['scheme'] . "://";
+
+        if(isset($parsed['host']))
+            $origin .= $parsed['host'];
+
+        if(isset($parsed['port']))
+            $origin .= ":" . $parsed['port'];
+
+        return $origin;
     }
 
     private function get_authorization_url( Auth_State $state ) {

--- a/plugins/bcc-login/includes/class-bcc-login-visibility.php
+++ b/plugins/bcc-login/includes/class-bcc-login-visibility.php
@@ -103,12 +103,14 @@ class BCC_Login_Visibility {
             return;
         }
 
+        $visited_url = "$_SERVER[REQUEST_SCHEME]://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+
         $session_is_valid = $this->_client->is_session_valid();
 
         // Initiate new login if session has expired
         if ( is_user_logged_in() && !$session_is_valid ) {
             $this->_client->end_login();
-            $this->_client->start_login();
+            wp_redirect( wp_login_url($visited_url) );
             return;
         }
 
@@ -135,7 +137,7 @@ class BCC_Login_Visibility {
             if ( is_user_logged_in() ) {
                 return $this->not_allowed_to_view_page();
             } else {
-               $this->_client->start_login();
+                wp_redirect( wp_login_url($visited_url) );
             }
         }
 


### PR DESCRIPTION
Fixes issue with cached login redirect responses by first always redirecting to wp_login.php which is never cached.

closes #132