### PR TITLE
Remove added query parameters after login redirect

### DIFF
--- a/plugins/bcc-login/includes/class-bcc-login-client.php
+++ b/plugins/bcc-login/includes/class-bcc-login-client.php
@@ -271,41 +271,23 @@ class BCC_Login_Client {
     private function get_current_url() {
         global $wp;
         if(isset($_GET['redirect_to'])) {
-            if( $this->parse_url_origin($_GET['redirect_to']) !==  $this->parse_url_origin(site_url()) ) {
+            if( $this->parse_url_host($_GET['redirect_to']) !==  $this->parse_url_host(site_url()) ) {
                 return "/";
             }
-            
             return $_GET['redirect_to'];
         }
 
-        // If the Permalink Structure is set to Plain we use the old solution with $_SERVER
-        if( get_option('permalink_structure') != "") {
-            return add_query_arg( $_SERVER['QUERY_STRING'], '', home_url( $wp->request ) );
-        }
-        else {
-            // We replace 'wp-login.php' to 'wp-admin' to avoid the redirect loop when logging through SSO directly to the admin dashboard
-            return $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . str_replace('wp-login.php', 'wp-admin', $_SERVER['REQUEST_URI']);
-        }
+        return '//' . $_SERVER['HTTP_HOST'] . str_replace('wp-login.php', '', $_SERVER['REQUEST_URI']);
     }
 
-    private function parse_url_origin($url) {
-        $origin = "";
-
+    private function parse_url_host($url) {
         $parsed = parse_url($url);
 
-        if ($parsed === false) {
-            return $origin;
+        if ($parsed === false || !isset($parsed['host'])) {
+            return "";
         }
-        if(isset($parsed['scheme']))
-            $origin .= $parsed['scheme'] . "://";
 
-        if(isset($parsed['host']))
-            $origin .= $parsed['host'];
-
-        if(isset($parsed['port']))
-            $origin .= ":" . $parsed['port'];
-
-        return $origin;
+        return $parsed['host'];
     }
 
     private function get_authorization_url( Auth_State $state ) {

--- a/plugins/bcc-login/includes/class-bcc-login-visibility.php
+++ b/plugins/bcc-login/includes/class-bcc-login-visibility.php
@@ -105,7 +105,7 @@ class BCC_Login_Visibility {
             return;
         }
 
-        $visited_url = add_query_arg( $wp->query_vars, home_url( $wp->request ) );
+        $visited_url = "//".$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
 
         $session_is_valid = $this->_client->is_session_valid();
 


### PR DESCRIPTION
Makes following changes to improve robustness of the login redirect

1. Use redirects without schema - on some PHP environments (kinsta) `$_SERVER['REQUEST_SCHEMA']` is not available, so to make sure redirects work in those environments we omit schema from redirect links
2. Going directly to `/wp-login.php` redirects to home page after login, not `wp-admin` - This behavior used to depend on whether permalink structure was set to plain or pretty; this difference doesn't make sense and we should consolidate on always redirecting to home page, if someone wants to directly access the admin panel they should go to `/wp-admin`
3. Only use host for validating redirects, this had to be done, so the redirects without schema work.