### PR TITLE
Fix transient for target groups

### DIFF
--- a/plugins/bcc-login/includes/class-bcc-coreapi-client.php
+++ b/plugins/bcc-login/includes/class-bcc-coreapi-client.php
@@ -10,22 +10,21 @@ class BCC_Coreapi_Client
     {
         $this->_settings = $login_settings;
         $this->_storage = $storage;
-
     }
 
     function get_site_groups() {
         if (isset($this->_site_groups)) {
             return $this->_site_groups;
         }
-        $group_uids = $this->_settings->site_groups;
 
-        $cache_key = 'coreapi_groups_' . implode($group_uids);
-
+        $cache_key = 'coreapi_groups';
         $cached_response = get_transient($cache_key);
+
         if ($cached_response !== false) {
             return $cached_response;
         }
 
+        $group_uids = $this->_settings->site_groups;
         $this->_site_groups = $this->fetch_groups($group_uids);
         $this->translate_site_groups();
 

--- a/plugins/bcc-login/includes/class-bcc-login-settings.php
+++ b/plugins/bcc-login/includes/class-bcc-login-settings.php
@@ -120,6 +120,7 @@ class BCC_Login_Settings_Provider {
 
         add_action( 'admin_menu', array( $this, 'add_options_page' ) );
         add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'update_option_bcc_site_groups', array( $this, 'on_site_groups_option_update' ), 10, 3 );
     }
 
     /**
@@ -411,6 +412,13 @@ class BCC_Login_Settings_Provider {
                 <?php endif; ?>
             </p>
         <?php endif;
+    }
+
+    /**
+     * Action hook for bcc_site_groups option update.
+     */
+    function on_site_groups_option_update($old_value, $value, $option) {
+        delete_transient('coreapi_groups');
     }
 
     /**


### PR DESCRIPTION
The transient name was too long (exceeding the 172 characters limit).