### PR TITLE
Address use-case when the cached response is empty

### DIFF
--- a/plugins/bcc-login/includes/class-bcc-coreapi-client.php
+++ b/plugins/bcc-login/includes/class-bcc-coreapi-client.php
@@ -26,7 +26,7 @@ class BCC_Coreapi_Client
         $cache_key = 'coreapi_groups';
         $cached_response = get_transient($cache_key);
 
-        if ($cached_response !== false) {
+        if ($cached_response !== false && !empty($cached_response)) {
             return $cached_response;
         }
 


### PR DESCRIPTION
And not false, as described in the documentation