### PR TITLE
Skip get_posts filter for Phrase calls

### DIFF
--- a/plugins/bcc-login/includes/class-bcc-login-visibility.php
+++ b/plugins/bcc-login/includes/class-bcc-login-visibility.php
@@ -420,9 +420,12 @@ class BCC_Login_Visibility {
         // Don't filter posts for Phrase
         // Check if Phrase (Memsource) is installed
         if ( class_exists('\Memsource\Utils\AuthUtils') ) {
-            // Validate the token in the request
-            if ( \Memsource\Utils\AuthUtils::validateTokenInRequest() ) {
-                return $query;
+            // Check if there's any token in the request
+            if ( \Memsource\Utils\AuthUtils::getTokenFromRequest() != false ) {
+                // Validate the token in the request
+                if ( \Memsource\Utils\AuthUtils::validateTokenInRequest() ) {
+                    return $query;
+                }
             }
         }
 

--- a/plugins/bcc-login/includes/class-bcc-login-visibility.php
+++ b/plugins/bcc-login/includes/class-bcc-login-visibility.php
@@ -312,7 +312,6 @@ class BCC_Login_Visibility {
                 'before'
             );
         }
-
     }
 
     /**
@@ -323,13 +322,22 @@ class BCC_Login_Visibility {
      * @return WP_Query
      */
     function filter_pre_get_posts( $query ) {
+        // Don't filter posts for Phrase
+        // Check if Phrase (Memsource) is installed
+        if ( class_exists('\Memsource\Utils\AuthUtils') ) {
+            // Validate the token in the request
+            if ( \Memsource\Utils\AuthUtils::validateTokenInRequest() ) {
+                return $query;
+            }
+        }
+
         if ( current_user_can( 'edit_posts' ) || $query->is_singular ) {
             return $query;
         }
 
-        // Don't filter visibility for not supported post types
+        // Don't filter posts for not supported post types
         // Menu items are e.g. handled in 'filter_menu_items()'
-        if ( !$this->supports_visibility_filter($query))  {
+        if ( !$this->supports_visibility_filter($query) ) {
             return $query;
         }
 
@@ -485,8 +493,6 @@ class BCC_Login_Visibility {
      * @return WP_Post[]
      */
     function filter_menu_items( $items ) {
-
-
         $level   = $this->_client->get_current_user_level();
         $removed = array();
 


### PR DESCRIPTION
This allows Phrase to fetch both posts with Logged in Post audience and posts assigned to some Post groups.